### PR TITLE
docs: fix broken links and add doc standards

### DIFF
--- a/docs/artillery.md
+++ b/docs/artillery.md
@@ -2,12 +2,11 @@
 
 ## Table of Contents <!-- omit in toc -->
 
-- [Artillery Load Testing](#artillery-load-testing)
-  - [Installation](#installation)
-  - [Setup](#setup)
-  - [Module Specific Files](#module-specific-files)
-  - [How to Run the File](#how-to-run-the-files)
-  - [How to Increase the Load](#how-to-increase-the-load)
+- [Installation](#installation)
+- [Setup](#setup)
+- [Module Specific Files](#module-specific-files)
+- [How to Run the Files](#how-to-run-the-files)
+- [How to Increase the Load](#how-to-increase-the-load)
 
 ---
 

--- a/docs/documentation-standards.md
+++ b/docs/documentation-standards.md
@@ -1,0 +1,107 @@
+# Documentation Standards
+
+Quick reference for maintaining consistent NestForge documentation.
+
+## 📋 Quick Reference
+
+### TOC Format
+```markdown
+## Table of Contents <!-- omit in toc -->
+
+- [Section 1](#section-1)
+- [Section 2](#section-2)
+  - [Subsection 2.1](#subsection-21)
+```
+
+**Rules:**
+- No self-referencing links (title/TOC in TOC)
+- Use `<!-- omit in toc -->` comment
+- 2-space indentation for subsections
+- Match anchor links exactly
+
+### Headings
+- `#` - Document title (only one per document)
+- `##` - Main sections  
+- `###` - Subsections
+- Use sentence case: "Installation and setup"
+- Be descriptive: "Database Configuration" not "Config"
+
+### Code Blocks
+Always specify language:
+```typescript
+// TypeScript code
+const example = 'value';
+```
+
+### Links
+- **Internal**: `[Architecture Guide](architecture.md)`
+- **External**: `[NestJS Docs](https://docs.nestjs.com/)`
+- **Anchors**: `[Setup Script](setup-script.md#usage)`
+
+### File Naming
+- Use kebab-case: `setup-script.md`
+- Be descriptive: `database-migrations.md` not `db.md`
+
+## 📝 Content Guidelines
+
+### Writing Style
+- **Active voice**: "Run the command" not "The command should be run"
+- **Be concise**: Get to the point quickly
+- **Use bullet points**: For lists and steps
+- **Include examples**: Show, don't just tell
+- **Add prerequisites**: Always mention what's needed before starting
+
+### Document Structure
+1. **Overview** - Brief description of what the document covers
+2. **Prerequisites** - What users need before starting
+3. **Step-by-step instructions** - Clear, numbered steps
+4. **Examples and code** - Practical demonstrations
+5. **Troubleshooting** - Common issues and solutions
+6. **References** - Links to related documentation
+
+### Navigation
+Include navigation links at the bottom:
+```markdown
+---
+
+Previous: [Previous Document](previous-doc.md)
+
+Next: [Next Document](next-doc.md)
+```
+
+## 🔗 Link Validation
+
+### Common Issues to Avoid
+- ❌ Broken file references → Ensure linked files exist
+- ❌ Missing anchors → Ensure `#section-name` exists
+- ❌ Wrong paths → Use `../` for parent directory
+- ❌ Missing extensions → Always include `.md`
+
+### Quick Checklist
+- [ ] All internal links use relative paths
+- [ ] All linked files exist
+- [ ] Anchor links point to existing sections
+- [ ] Navigation links use correct relative paths
+
+## ✅ Review Checklist
+
+### Before Submitting Changes
+- [ ] TOC follows standard format
+- [ ] All internal links work
+- [ ] Code blocks have language specified
+- [ ] File naming follows conventions
+- [ ] Content is clear and concise
+- [ ] Prerequisites are clearly stated
+- [ ] Examples are complete and runnable
+- [ ] Navigation links are included
+
+### Quality Checks
+- [ ] No typos or grammar errors
+- [ ] Consistent terminology throughout
+- [ ] Proper heading hierarchy
+- [ ] Cross-references are accurate
+- [ ] External links are valid
+
+---
+
+*This document should be updated as new standards are established.*

--- a/docs/hygen/index.md
+++ b/docs/hygen/index.md
@@ -26,6 +26,6 @@ Use these guides to scaffold modules consistently. Each page documents:
 
 ---
 
-Previous: [Architecture](architecture.md)
+Previous: [Architecture](../architecture.md)
 
-Next: [Working with database](database.md)
+Next: [Working with database](../database.md)

--- a/docs/installing-and-running.md
+++ b/docs/installing-and-running.md
@@ -2,7 +2,7 @@
 
 This project is using [TypeORM](https://www.npmjs.com/package/typeorm) along with [PostgreSQL](https://www.postgresql.org/).
 
-Interactions with the database are implemented based on [Hexagonal Architecture](architecture.md#hexagonal-architecture). Benefits of this architecture are described in detail in the [benefits](architecture.md#benefits) section.
+Interactions with the database are implemented based on [Hexagonal Architecture](architecture.md#hexagonal-architecture). Benefits of this architecture are described in detail in the [Conceptual Benefits](architecture.md#conceptual-benefits) and [Practical Benefits](architecture.md#practical-benefits-of-hexagonal-architecture) sections.
 
 ---
 

--- a/docs/setup-script.md
+++ b/docs/setup-script.md
@@ -6,7 +6,6 @@ The `scripts/setup.sh` script provides an automated way to set up your NestForge
 
 ## Table of Contents
 
-- [Table of Contents](#table-of-contents)
 - [Prerequisites](#prerequisites)
 - [What the Script Does](#what-the-script-does)
 - [Interactive Prompts](#interactive-prompts)


### PR DESCRIPTION
## Documentation Improvements

### Fixed
- **TOC inconsistencies** in `docs/artillery.md` and `docs/setup-script.md`
- **Broken internal links** across documentation files
- **Relative path issues** in `docs/hygen/index.md` navigation
- **Anchor link references** in `docs/installing-and-running.md`

### Added
- **Documentation standards** (`docs/documentation-standards.md`) for consistent formatting
- **Link validation guidelines** to prevent future broken links
- **Comprehensive review checklist** for documentation quality

### Impact
- All internal links now work correctly
- Standardized TOC format across all docs
- Improved documentation maintainability
- Better developer experience when navigating docs

**Note**: `cli.md` references remain unfixed pending resolution of missing file issue. [Created this issue ](https://github.com/hhsadiq/NestForge/issues/27)